### PR TITLE
Accept gff3 file extension as well

### DIFF
--- a/cmd/samvariants.go
+++ b/cmd/samvariants.go
@@ -112,6 +112,8 @@ Frame-shifting mutations in coding sequence are reported as indels but are ignor
 				annoSuffix = "gb"
 			case ".gff":
 				annoSuffix = "gff"
+			case ".gff3":
+				annoSuffix = "gff"
 			default:
 				return errors.New("couldn't tell if --annotation was a .gb or a .gff file")
 			}

--- a/cmd/variants.go
+++ b/cmd/variants.go
@@ -116,6 +116,8 @@ Frame-shifting mutations in coding sequence are reported as indels but are ignor
 				annoSuffix = "gb"
 			case ".gff":
 				annoSuffix = "gff"
+			case ".gff3":
+				annoSuffix = "gff"
 			default:
 				return errors.New("couldn't tell if --annotation was a .gb or a .gff file")
 			}


### PR DESCRIPTION
gofasta requires gff file extension but it actually assumes gff3 file format. Do not be so pesky about filename extension and accept also gff3 suffix.

Bug: https://github.com/virus-evolution/gofasta/issues/44