### PR TITLE
Add code skeleton to output sequence of new codon around mutated site

### DIFF
--- a/pkg/variants/pairwise.go
+++ b/pkg/variants/pairwise.go
@@ -82,6 +82,14 @@ func getNucsPair(ref, query []byte, pos []int, offsetRefCoord []int, offsetMSACo
 	return variants
 }
 
+func getCodonNucs(ref, query []byte, pos []int, offsetRefCoord []int, offsetMSACoord []int) []Variant {
+        DA := encoding.MakeDecodingArray()
+        variants := make([]Variant, 0)
+	// TODO: figure out if the mutation is in the first, second or third nucleotide position of a codon
+	// TODO: slice out the respective nucleotide region around DA[query[alignPos]]
+        return variants
+}
+
 // a version of the function that uses the Positions slice in the Region instead of the CodonStarts
 func getAAsPair(ref, query []byte, region Region, offsetRefCoord []int, offsetMSACoord []int) []Variant {
 


### PR DESCRIPTION
This roughly sketches places which need to be added to provide codon sequence and their frequency in the output. I never wrote anything in GO so this is an incomplete. The pkg/variants/pairwise.go needs more work to figure out where is the current mutation located in respect to the codon and then slice out the three nucleotides including current position.