### PR TITLE
Add codon representation

### DIFF
--- a/cmd/samvariants.go
+++ b/cmd/samvariants.go
@@ -124,7 +124,7 @@ Frame-shifting mutations in coding sequence are reported as indels but are ignor
 		}
 		defer out.Close()
 
-		err = sam.Variants(samIn, ref, refFromFile, anno, annoSuffix, out, samVariantsStart, samVariantsEnd, samVariantsAggregate, samVariantsThreshold, samVariantsAppendSNP, samThreads)
+		err = sam.Variants(samIn, ref, refFromFile, anno, annoSuffix, out, samVariantsStart, samVariantsEnd, samVariantsAggregate, samVariantsThreshold, samVariantsAppendSNP, false, samThreads)
 
 		return err
 	},

--- a/cmd/samvariants.go
+++ b/cmd/samvariants.go
@@ -16,6 +16,7 @@ var samVariantsOutfile string
 var samVariantsAggregate bool
 var samVariantsThreshold float64
 var samVariantsAppendSNP bool
+var samVariantsAppendCodons bool
 var samVariantsStart int
 var samVariantsEnd int
 
@@ -32,9 +33,11 @@ func init() {
 	samVariantsCmd.Flags().BoolVarP(&samVariantsAggregate, "aggregate", "", false, "Report the proportions of each change")
 	samVariantsCmd.Flags().Float64VarP(&samVariantsThreshold, "threshold", "", 0.0, "If --aggregate, only report changes with a freq greater than or equal to this value")
 	samVariantsCmd.Flags().BoolVarP(&samVariantsAppendSNP, "append-snps", "", false, "Report the codon's SNPs in parenthesis after each amino acid mutation")
+	samVariantsCmd.Flags().BoolVarP(&samVariantsAppendCodons, "append-codons", "", false, "Report the codon's sequence in parenthesis after each amino acid mutation")
 
 	samVariantsCmd.Flags().Lookup("aggregate").NoOptDefVal = "true"
 	samVariantsCmd.Flags().Lookup("append-snps").NoOptDefVal = "true"
+	samVariantsCmd.Flags().Lookup("append-codons").NoOptDefVal = "true"
 
 	samVariantsCmd.Flags().SortFlags = false
 
@@ -124,7 +127,7 @@ Frame-shifting mutations in coding sequence are reported as indels but are ignor
 		}
 		defer out.Close()
 
-		err = sam.Variants(samIn, ref, refFromFile, anno, annoSuffix, out, samVariantsStart, samVariantsEnd, samVariantsAggregate, samVariantsThreshold, samVariantsAppendSNP, false, samThreads)
+		err = sam.Variants(samIn, ref, refFromFile, anno, annoSuffix, out, samVariantsStart, samVariantsEnd, samVariantsAggregate, samVariantsThreshold, samVariantsAppendSNP, samVariantsAppendCodons, samThreads)
 
 		return err
 	},

--- a/cmd/variants.go
+++ b/cmd/variants.go
@@ -19,6 +19,7 @@ var variantsThreads int
 var variantsAggregate bool
 var variantsThreshold float64
 var variantsAppendSNP bool
+var variantsAppendCodons bool // Add new flag variable
 var variantsStart int
 var variantsEnd int
 
@@ -37,10 +38,12 @@ func init() {
 	variantsCmd.Flags().BoolVarP(&variantsAggregate, "aggregate", "", false, "Report the proportions of each change")
 	variantsCmd.Flags().Float64VarP(&variantsThreshold, "threshold", "", 0.0, "If --aggregate, only report changes with a freq greater than or equal to this value")
 	variantsCmd.Flags().BoolVarP(&variantsAppendSNP, "append-snps", "", false, "Report the codon's SNPs in parenthesis after each amino acid mutation")
+	variantsCmd.Flags().BoolVarP(&variantsAppendCodons, "append-codons", "", false, "Report the reference and alternate codons after each amino acid mutation") // Add new flag definition
 	variantsCmd.Flags().IntVarP(&variantsThreads, "threads", "t", 1, "Number of threads to use")
 
 	variantsCmd.Flags().Lookup("aggregate").NoOptDefVal = "true"
 	variantsCmd.Flags().Lookup("append-snps").NoOptDefVal = "true"
+	variantsCmd.Flags().Lookup("append-codons").NoOptDefVal = "true" // Add NoOptDefVal for the new flag
 
 	variantsCmd.Flags().StringVarP(&variantsGenbank, "genbank", "", "", "Genbank format annotation")
 	variantsCmd.Flags().MarkHidden("genbank")
@@ -128,7 +131,7 @@ Frame-shifting mutations in coding sequence are reported as indels but are ignor
 		}
 		defer out.Close()
 
-		err = variants.Variants(msa, stdin, variantsReference, anno, annoSuffix, out, variantsStart, variantsEnd, variantsAggregate, variantsThreshold, variantsAppendSNP, variantsThreads)
+		err = variants.Variants(msa, stdin, variantsReference, anno, annoSuffix, out, variantsStart, variantsEnd, variantsAggregate, variantsThreshold, variantsAppendSNP, variantsAppendCodons, variantsThreads) // Pass new flag
 
 		return
 	},

--- a/pkg/sam/variants.go
+++ b/pkg/sam/variants.go
@@ -18,7 +18,7 @@ import (
 // outside of codons with an amino acid change) mutations relative to a reference
 // sequence from pairwise alignments in sam format. Genome annotations are
 // derived from a annotation file in genbank or gff version 3 format
-func Variants(samIn, refIn io.Reader, refFromFile bool, annoIn io.Reader, annoSuffix string, out io.Writer, start, end int, aggregate bool, threshold float64, appendSNP bool, threads int) error {
+func Variants(samIn, refIn io.Reader, refFromFile bool, annoIn io.Reader, annoSuffix string, out io.Writer, start, end int, aggregate bool, threshold float64, appendSNP bool, appendCodons bool, threads int) error {
 
 	var ref fasta.EncodedRecord
 	if refFromFile {
@@ -100,9 +100,9 @@ func Variants(samIn, refIn io.Reader, refFromFile bool, annoIn io.Reader, annoSu
 
 	switch aggregate {
 	case true:
-		go variants.AggregateWriteVariants(out, start, end, appendSNP, threshold, ref.ID, cVariants, cWriteDone, cErr)
+		go variants.AggregateWriteVariants(out, start, end, appendSNP, appendCodons, threshold, ref.ID, cVariants, cWriteDone, cErr)
 	case false:
-		go variants.WriteVariants(out, start, end, false, appendSNP, ref.ID, cVariants, cWriteDone, cErr)
+		go variants.WriteVariants(out, start, end, false, appendSNP, appendCodons, ref.ID, cVariants, cWriteDone, cErr)
 	}
 
 	go groupSamRecords(samIn, cSH, cSR, cReadDone, cErr)

--- a/pkg/variants/pairwise.go
+++ b/pkg/variants/pairwise.go
@@ -91,7 +91,7 @@ func getAAsPair(ref, query []byte, region Region, offsetRefCoord []int, offsetMS
 	variants := make([]Variant, 0)
 	codonSNPs := make([]Variant, 0, 3)
 
-	var decodedCodon, aa, refaa string
+	var decodedCodon, refDecodedCodon, aa, refaa string // Add refDecodedCodon
 	aaCounter := 0
 	codonCounter := 0
 
@@ -110,6 +110,7 @@ func getAAsPair(ref, query []byte, region Region, offsetRefCoord []int, offsetMS
 			// IF ON THE REVERSE STRAND- WHICH NUCLEOTIDE SHOULD BE REPRESENTED IN THE NUC VARIANT?
 		}
 		decodedCodon = decodedCodon + DA[query[alignmentPos]]
+		refDecodedCodon = refDecodedCodon + DA[ref[alignmentPos]] // Build reference codon
 
 		codonCounter++
 
@@ -118,6 +119,7 @@ func getAAsPair(ref, query []byte, region Region, offsetRefCoord []int, offsetMS
 			// we're already going in the reverse direction, so don't need the reverse complement)
 			if region.Strand == -1 {
 				decodedCodon = alphabet.Complement(decodedCodon)
+				refDecodedCodon = alphabet.Complement(refDecodedCodon) // Complement reference codon if reverse strand
 			}
 
 			if _, ok := CD[decodedCodon]; ok {
@@ -133,7 +135,7 @@ func getAAsPair(ref, query []byte, region Region, offsetRefCoord []int, offsetMS
 				for _, v := range codonSNPs {
 					temp = append(temp, "nuc:"+v.RefAl+strconv.Itoa(v.Position)+v.QueAl)
 				}
-				variants = append(variants, Variant{Changetype: "aa", Feature: region.Name, RefAl: refaa, QueAl: aa, Position: refPos - (2 * region.Strand), Residue: aaCounter + 1, SNPs: strings.Join(temp, ";")})
+				variants = append(variants, Variant{Changetype: "aa", Feature: region.Name, RefAl: refaa, QueAl: aa, Position: refPos - (2 * region.Strand), Residue: aaCounter + 1, SNPs: strings.Join(temp, ";"), RefCodon: refDecodedCodon, QueCodon: decodedCodon}) // Add codons to Variant
 
 			} else {
 				for _, v := range codonSNPs {
@@ -143,6 +145,7 @@ func getAAsPair(ref, query []byte, region Region, offsetRefCoord []int, offsetMS
 
 			codonSNPs = make([]Variant, 0, 3)
 			decodedCodon = ""
+			refDecodedCodon = "" // Reset reference codon
 			codonCounter = 0
 			aaCounter++
 		}

--- a/pkg/variants/variants.go
+++ b/pkg/variants/variants.go
@@ -717,11 +717,11 @@ func FormatVariant(v Variant, appendSNP bool, appendCodons bool) (string, error)
 		s = "nuc:" + v.RefAl + strconv.Itoa(v.Position) + v.QueAl
 	case "aa":
 		if appendSNP && appendCodons {
-			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")" + "[" + v.RefCodon + "->" + v.QueCodon + "]"
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")" + "(" + v.RefCodon + "->" + v.QueCodon + ")"
 		} else if appendSNP {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")"
 		} else if appendCodons {
-			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "[" + v.RefCodon + "->" + v.QueCodon + "]"
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.RefCodon + "->" + v.QueCodon + ")"
 		} else {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl
 		}

--- a/pkg/variants/variants.go
+++ b/pkg/variants/variants.go
@@ -717,11 +717,11 @@ func FormatVariant(v Variant, appendSNP bool, appendCodons bool) (string, error)
 		s = "nuc:" + v.RefAl + strconv.Itoa(v.Position) + v.QueAl
 	case "aa":
 		if appendSNP && appendCodons {
-			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")" + "(" + v.RefCodon + "->" + v.QueCodon + ")"
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")" + "(ref:" + v.RefCodon + "alt:" + v.QueCodon + ")"
 		} else if appendSNP {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")"
 		} else if appendCodons {
-			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.RefCodon + "->" + v.QueCodon + ")"
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(ref:" + v.RefCodon + "alt:" + v.QueCodon + ")"
 		} else {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl
 		}

--- a/pkg/variants/variants.go
+++ b/pkg/variants/variants.go
@@ -716,8 +716,12 @@ func FormatVariant(v Variant, appendSNP bool, appendCodons bool) (string, error)
 	case "nuc":
 		s = "nuc:" + v.RefAl + strconv.Itoa(v.Position) + v.QueAl
 	case "aa":
-		if appendSNP {
+		if appendSNP && appendCodons {
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")" + "[" + v.RefCodon + "->" + v.QueCodon + "]"
+		} else if appendSNP {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")"
+		} else if appendCodons {
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "[" + v.RefCodon + "->" + v.QueCodon + "]"
 		} else {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl
 		}

--- a/pkg/variants/variants.go
+++ b/pkg/variants/variants.go
@@ -717,11 +717,11 @@ func FormatVariant(v Variant, appendSNP bool, appendCodons bool) (string, error)
 		s = "nuc:" + v.RefAl + strconv.Itoa(v.Position) + v.QueAl
 	case "aa":
 		if appendSNP && appendCodons {
-			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")" + "(ref:" + v.RefCodon + "alt:" + v.QueCodon + ")"
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")" + "(ref:" + v.RefCodon + " alt:" + v.QueCodon + ")"
 		} else if appendSNP {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")"
 		} else if appendCodons {
-			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(ref:" + v.RefCodon + "alt:" + v.QueCodon + ")"
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(ref:" + v.RefCodon + " alt:" + v.QueCodon + ")"
 		} else {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl
 		}

--- a/pkg/variants/variants.go
+++ b/pkg/variants/variants.go
@@ -717,11 +717,11 @@ func FormatVariant(v Variant, appendSNP bool, appendCodons bool) (string, error)
 		s = "nuc:" + v.RefAl + strconv.Itoa(v.Position) + v.QueAl
 	case "aa":
 		if appendSNP && appendCodons {
-			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")" + "(ref:" + v.RefCodon + " alt:" + v.QueCodon + ")"
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")" + "(ref:" + v.RefCodon + "-alt:" + v.QueCodon + ")"
 		} else if appendSNP {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(" + v.SNPs + ")"
 		} else if appendCodons {
-			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(ref:" + v.RefCodon + " alt:" + v.QueCodon + ")"
+			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl + "(ref:" + v.RefCodon + "-alt:" + v.QueCodon + ")"
 		} else {
 			s = "aa:" + v.Feature + ":" + v.RefAl + strconv.Itoa(v.Residue) + v.QueAl
 		}


### PR DESCRIPTION
I've made some improvements to how variants are formatted, particularly focusing on displaying codons. The main changes include:

- Added the ability to show codons in the variant output

- Made the FormatVariant function more flexible so it can handle different ways of showing SNPs and codons

- Updated the Variant struct to keep track of both reference and query(alternate) codons

- Added new "append-codon" flag to control whether codons are shown in the output

These changes should make it easier to analyze protein-coding regions while keeping everything working as before. I've tested the changes to make sure they work as expected. Thank you.